### PR TITLE
Refactor homepage HTML, add papers index page, and consolidate styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,40 +2,29 @@
 <head>
   <title>Shiyu Zhang Complex Geometry</title>
   <meta name="google-site-verification" content="iiVqSYgyMZaSKjwBvW68iFKeEzjvsk_R_WuHS7sTOfA" />
-  <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
-</script>
-  <script type="text/x-mathjax-config">
-    MathJax.Hub.Config({
-        tex2jax: {inlineMath: [['$', '$']]},
-        messageStyle: "none"
-    });
-</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body {
+      background-color: #FFFFFF;
+      padding-left: 30px;
+    }
+
+    h1, h2, h3, h4, h5 {
+      color: #333333;
+    }
+
+    a {
+      color: #6495ED;
+    }
+
+    li {
+      margin-bottom: 10px;
+    }
+  </style>
 </head>
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document with Table of Contents</title>
-</head>
-  
-<head>
-    <style>
-        body {
-            padding-left: 30px;  /* 设置页面左边的空白 */
-        }
-    </style>
-</head>
-
-<body style="background-color: #FFFFFF;">
-<style>
-h1, h2, h3, h4, h5 {
-  color: #333333; /* 浅黑色 */
-}
-
-a {
-  color: #6495ED; /* 柔和的粉色 */
-}
-</style>
+<body>
 <h1>Shiyu Zhang</h1>
 <p>
 <b>About me</b>：I am a researcher in mathematics from China. You can find me by email "shiyu123@mail.ustc.edu.cn".
@@ -49,105 +38,20 @@ a {
   <p> &middot The relationship between rational connectedness and semi-positive differential-geometric curvature.
 <hr>
 
-<h2>Latest talks and conferences (<a href="https://BerkovichYu.github.io/conferences">More)</a></h2>
-<p>
-  <details>
-  <summary>Non-abelian Hodge correspondence and the Miyaoka-Yau equality over singular varieties, Workshop on Geometric Analysis 2026, PhD student report, May 24-29, 珠海</summary>
-  <p>
-    I will talk about recent work [5, 6].
-  </p>
-  </details>
-</p>
-
-<hr>
-  
-<h2 id="Preprints">Preprints and Publications (<a href="https://scholar.google.com/citations?hl=en&user=x2xD6cAAAAAJ&view_op=list_works&sortby=pubdate">Google Scholar</a>)</h2>
-Presented in chronological order with summaries and remarks (please click title).
-<p>
-<details>
-  <summary> 6. <span> Non-abelian Hodge corrrespondence over singular K\"ahler spaces, with Chuanjing Zhang and Xi Zhang, <a href="https://arxiv.org/abs/2601.13071"> arxiv preprint:2601.12071</a>. </span> </summary>
-<p> 
-  In this paper, we establish the nonabelian Hodge correspondence over compact K\"ahler klt spaces as well as their regular loci, thereby generalizing the previous result of Greb-Kebekus-Peternell-Taji for projective klt varieties.
-<p> As an interesting application, we prove that if a projective klt variety with big canonical divisor satisfies the orbifold Miyaoka-Yau type equality in the sense of the previous work [5] joint with M. Iwai and S. Jinnouchi, then its canonical model must be a singular quotient of the unit ball. 
-  See also Jinnouchi's <a href="https://arxiv.org/abs/2512.24161"> recent preprint</a> for K-stable klt varieties with big anti-canonical divisor. 
-  Toghther, these results confirm the Miyaoka-Yau inequality formulated via non-pluripolar product developed in the paper [5] provide an effective criterion for projective klt varieties with big canonical divisor.
-</details>
-<p>
-  
-<p>
-<details>
-  <summary> 5. <span> Miyaoka-Yau inequality for singular varieties with big canonical or anticanonical divisor. with <a href="https://masataka123.github.io/blog3_e/">Masataka Iwai</a> and Satoshi Jinnouchi, <a href="https://arxiv.org/abs/2507.08522">arxiv preprint:2507.08522v2</a>. </span> </summary>
-<p> The main result is establishing the Miyaoka-Yau inequality for projective klt varieties with big canonical divisor.
-<p> The basic idea is proving Bogomolov-Gieseker inequality formulated via the non-pluripolar product. When I discussed with M. Iwai how to extend it to the klt case, I contributed this work. 
-<p> A basic question is characterizing the equality case of Bogomolov-Gieseker inequality. It's subtle because we used the limiting process in the proof.
-</details>
-<p>
-
-<details>
-  <summary> 4. <span> Compact Kahler manifolds with partially semi-positive curvature, with Xi Zhang, <a href="https://arxiv.org/abs/2504.13155"></a> to appear in the Transactions of the American Mathematical Society. </span> </summary>
-<p>  Our first main result provides a new differential-geometric criterion for rational connectedness. We prove that a compact Kähler manifold is rationally connected if and only if its tangent bundle is BC-p positive for every p≥1. 
-     This notion of BC-p positivity is very weak and arises naturally from a Bochner-type formula associated with MRC fibrations (Proposition 3.3). 
-<p>  As a direct application, we confirm a conjecture of Prof. Lei Ni, showing that positive orthogonal Ricci curvature implies rational connectedness.
-<p>  Our second result establishes structure theorems for manifolds with semi-positive immediate curvature conditions, offering a natural generalization of several classical works.
-<p>  It would be interesting whether BC-p quasi-positivity (p≥1) imply the rational connectedness and BC-2 quasi-positivity implies the projectivity. 
-     The latter is posed by L. Ni. The former is posed by me and indeed implies a conjecture of Xiaokui Yang that quasi-positive uniformly RC-positivity ensures the rational connectedness. 
-<p>  I am grateful to Prof. Lei Ni for his attention to this work, and for his generous assistance on numerous other occasions.
-<p>  On a personal note, I must candidly share that the first version of this paper contained an error—specifically, a mistaken equality in a key integral inequality. 
-     It was the reviewer’s careful reading that patiently pointed out this issue. 
-     In the process of carefully revising those details, I discovered something new and came to a deeper understanding: mathematics is not only about grand visions and directions, but also emerges from meticulous attention to detail. 
-     We must take full responsibility for what we write.
-</details>
-<p>
-  
-<details>
-  <summary> 3. <span> The Miyaoka-Yau inequality on minimal Kahler spaces, with Chuanjing Zhang and Xi Zhang <a href="https://arxiv.org/abs/2503.13365">arXiv preprint:2503.13365</a>. </span> </summary>
-<p>  We extend the classical Miyaoka-Yau inequality to all minimal K\"ahler klt spaces.
-<p>  One key is the existence of orbifold modification by <a href="https://arxiv.org/abs/2512.20708">Kollar and Ou</a> for klt spaces. 
-<p>  This paper does provide a relatively general approach to considering Chern number inequalities and computing HN types of Higgs sheaves on K\"ahler KLT varieties.
-<p>  On the other hand, our argument is new for the smooth case. After completing this paper, Iwai shared an alternative approach with me. Please see the paper [5]. 
-<p>  Notably, the framework developed here—based on L^p approximate Hermitian–Einstein metrics—yields an important byproduct: 
-     we obtain the semistability (respectively, generic nefness) of torsion-free sheaves under symmetric powers, exterior powers, and tensor products in the singular setting.
-<p>  Finally, I should acknowledge that the first version of this paper contained an insufficient discussion of Harder–Narasimhan filtrations on singular varieties,
-     due to my then-unfamiliarity with certain technical aspects. That exposition was consequently difficult to follow; the present version supersedes it entirely.
-</details>
-<p>
-
-<p> 
-<details>
-  <summary> 2. <span> On the structure of compact Kahler manifolds with nonnegative holomorphic sectional curvature, with Xi Zhang, <a href="https://arxiv.org/abs/2311.18779"> arXiv preprint:2311.18779v4</a>. </span> </summary>
-<p> The main result is the establishment of a "pseudoeffective" version of Bochner-type theorem, which leads to a splitting of the tangent bundle. 
-<p> The innovation point is an elegant integral inequality.
-<p> This is a key step of the structure theorems of HSC≥0 for the Kahler case obtained by <a href="https://arxiv.org/abs/2502.00367">Professor S. Matsumura</a> recently.</p>
-<p> Concerning the nonnegative holomorphic sectional curvature, it remains open whether it implies some minimality in AG?
-</details>
-  
-<p>
-  <details>
-    <summary> 1. Regularizing property of the twisted conical Kahler-Ricci flow, with with <a href="https://math.njust.edu.cn/43/dd/c17271a345053/page5.htm">Jiawei Liu</a> and Xi Zhang, <a href="https://arxiv.org/pdf/2406.08778">arxiv preprint</a>. </summary>
-<p> The primary contribution to this work belongs to my collaborators. The most significant guidance throughout my doctoral studies undoubtedly came from my supervisor, yet I wish to express my deepest personal gratitude to my senior, Jiawei Liu. 
-  During my difficult third year of PhD, I was grappling with the Kähler-Ricci flow. At that time, Jiawei had already graduated and was conducting his research in Germany. 
-  Despite the distance and his own commitments, he offered me patient and consistent guidance through our online correspondence.
-  That period culminated in a painful personal realization: that this particular field might not be the right path for me. The sense of frustration and doubt was significant. 
-  Yet, looking back, I see that this very struggle—and the generous, remote mentorship he provided across continents—was fundamental. 
-  It was through this process that I truly learned how to engage with a research problem, how to question, and how to begin.
-  </details>
-<hr>
-
-<h2> Notes </h2>
-  <details>
-  <summary> 2. <span> Partial positivity, rational dimension and Bochner-type results, in the appendix of F. Bei's preprint "<a href="https://arxiv.org/abs/2602.11002v2">Simply connectedness of Kähler and Riemannian manifolds via spectral estimates</a>".  </summary>
-  <p> A small remark.
-</details>
-<p> 
-
-<p>
-  <details>
-  <summary> 1. <span> (a four-page) Remark on quasi-negative k-Ricci curvature. <a href="https://arxiv.org/abs/2508.17237">arxiv preprint:2508.17237</a></span>  </summary>
-<p> This is just a note, I present an improvement on a result by Chu, Lee, and Tam based on a use of Gauss-Codazzi equation.
-<p> An example of a projective manifold with negative k-Ricci curvature admits an embedding of P^k was claimed in <a href="https://arxiv.org/abs/2011.13508">a paper by Li--Ni--Zhu</a>, this was in fact a typographical error. Thank Prof. Lei Ni for kind clarification.
-<p> I will not revise this paper until I have made sure of the existence of this example. If someone find such an example, it will be nice because it means that the study on negative k-Ricci curvature indeed provide new perspectives than negative holomorphic sectional curvature. I am not good at construting an example.
-</details>
-
-<hr>
-<h2> <a href="https://BerkovichYu.github.io/Useful links">Collected articles </a> </h2>  
-<hr>
+<ul>
+  <li>
+    <b>Latest talks and conferences</b> (<a href="https://BerkovichYu.github.io/conferences">More</a>)
+    <p>
+      <details>
+      <summary>Non-abelian Hodge correspondence and the Miyaoka-Yau equality over singular varieties, Workshop on Geometric Analysis 2026, PhD student report, May 24-29, 珠海</summary>
+      <p>
+        I will talk about recent work [5, 6].
+      </p>
+      </details>
+    </p>
+  </li>
+  <li><b><a href="papers/">Papers</a></b> (<a href="https://scholar.google.com/citations?hl=en&user=x2xD6cAAAAAJ&view_op=list_works&sortby=pubdate">Google Scholar</a>)</li>
+  <li><b><a href="Useful%20links/">Useful links</a></b></li>
+</ul>
+</body>
+</html>

--- a/papers/index.html
+++ b/papers/index.html
@@ -1,0 +1,124 @@
+<html>
+<head>
+  <title>Shiyu Zhang Papers</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+</script>
+  <script type="text/x-mathjax-config">
+    MathJax.Hub.Config({
+        tex2jax: {inlineMath: [['$', '$']]},
+        messageStyle: "none"
+    });
+</script>
+  <style>
+    body {
+      background-color: #FFFFFF;
+      padding-left: 30px;
+    }
+
+    h1, h2, h3, h4, h5 {
+      color: #333333;
+    }
+
+    a {
+      color: #6495ED;
+    }
+  </style>
+</head>
+
+<body>
+<h1>Shiyu Zhang</h1>
+<p><a href="../">Home</a></p>
+<hr>
+<h2 id="Preprints">Preprints and Publications (<a href="https://scholar.google.com/citations?hl=en&user=x2xD6cAAAAAJ&view_op=list_works&sortby=pubdate">Google Scholar</a>)</h2>
+Presented in chronological order with summaries and remarks (please click title).
+<p>
+<details>
+  <summary> 6. <span> Non-abelian Hodge corrrespondence over singular K\"ahler spaces, with Chuanjing Zhang and Xi Zhang, <a href="https://arxiv.org/abs/2601.13071"> arxiv preprint:2601.12071</a>. </span> </summary>
+<p> 
+  In this paper, we establish the nonabelian Hodge correspondence over compact K\"ahler klt spaces as well as their regular loci, thereby generalizing the previous result of Greb-Kebekus-Peternell-Taji for projective klt varieties.
+<p> As an interesting application, we prove that if a projective klt variety with big canonical divisor satisfies the orbifold Miyaoka-Yau type equality in the sense of the previous work [5] joint with M. Iwai and S. Jinnouchi, then its canonical model must be a singular quotient of the unit ball. 
+  See also Jinnouchi's <a href="https://arxiv.org/abs/2512.24161"> recent preprint</a> for K-stable klt varieties with big anti-canonical divisor. 
+  Toghther, these results confirm the Miyaoka-Yau inequality formulated via non-pluripolar product developed in the paper [5] provide an effective criterion for projective klt varieties with big canonical divisor.
+</details>
+<p>
+  
+<p>
+<details>
+  <summary> 5. <span> Miyaoka-Yau inequality for singular varieties with big canonical or anticanonical divisor. with <a href="https://masataka123.github.io/blog3_e/">Masataka Iwai</a> and Satoshi Jinnouchi, <a href="https://arxiv.org/abs/2507.08522">arxiv preprint:2507.08522v2</a>. </span> </summary>
+<p> The main result is establishing the Miyaoka-Yau inequality for projective klt varieties with big canonical divisor.
+<p> The basic idea is proving Bogomolov-Gieseker inequality formulated via the non-pluripolar product. When I discussed with M. Iwai how to extend it to the klt case, I contributed this work. 
+<p> A basic question is characterizing the equality case of Bogomolov-Gieseker inequality. It's subtle because we used the limiting process in the proof.
+</details>
+<p>
+
+<details>
+  <summary> 4. <span> Compact Kahler manifolds with partially semi-positive curvature, with Xi Zhang, <a href="https://arxiv.org/abs/2504.13155"></a> to appear in the Transactions of the American Mathematical Society. </span> </summary>
+<p>  Our first main result provides a new differential-geometric criterion for rational connectedness. We prove that a compact Kähler manifold is rationally connected if and only if its tangent bundle is BC-p positive for every p≥1. 
+     This notion of BC-p positivity is very weak and arises naturally from a Bochner-type formula associated with MRC fibrations (Proposition 3.3). 
+<p>  As a direct application, we confirm a conjecture of Prof. Lei Ni, showing that positive orthogonal Ricci curvature implies rational connectedness.
+<p>  Our second result establishes structure theorems for manifolds with semi-positive immediate curvature conditions, offering a natural generalization of several classical works.
+<p>  It would be interesting whether BC-p quasi-positivity (p≥1) imply the rational connectedness and BC-2 quasi-positivity implies the projectivity. 
+     The latter is posed by L. Ni. The former is posed by me and indeed implies a conjecture of Xiaokui Yang that quasi-positive uniformly RC-positivity ensures the rational connectedness. 
+<p>  I am grateful to Prof. Lei Ni for his attention to this work, and for his generous assistance on numerous other occasions.
+<p>  On a personal note, I must candidly share that the first version of this paper contained an error—specifically, a mistaken equality in a key integral inequality. 
+     It was the reviewer’s careful reading that patiently pointed out this issue. 
+     In the process of carefully revising those details, I discovered something new and came to a deeper understanding: mathematics is not only about grand visions and directions, but also emerges from meticulous attention to detail. 
+     We must take full responsibility for what we write.
+</details>
+<p>
+  
+<details>
+  <summary> 3. <span> The Miyaoka-Yau inequality on minimal Kahler spaces, with Chuanjing Zhang and Xi Zhang <a href="https://arxiv.org/abs/2503.13365">arXiv preprint:2503.13365</a>. </span> </summary>
+<p>  We extend the classical Miyaoka-Yau inequality to all minimal K\"ahler klt spaces.
+<p>  One key is the existence of orbifold modification by <a href="https://arxiv.org/abs/2512.20708">Kollar and Ou</a> for klt spaces. 
+<p>  This paper does provide a relatively general approach to considering Chern number inequalities and computing HN types of Higgs sheaves on K\"ahler KLT varieties.
+<p>  On the other hand, our argument is new for the smooth case. After completing this paper, Iwai shared an alternative approach with me. Please see the paper [5]. 
+<p>  Notably, the framework developed here—based on L^p approximate Hermitian–Einstein metrics—yields an important byproduct: 
+     we obtain the semistability (respectively, generic nefness) of torsion-free sheaves under symmetric powers, exterior powers, and tensor products in the singular setting.
+<p>  Finally, I should acknowledge that the first version of this paper contained an insufficient discussion of Harder–Narasimhan filtrations on singular varieties,
+     due to my then-unfamiliarity with certain technical aspects. That exposition was consequently difficult to follow; the present version supersedes it entirely.
+</details>
+<p>
+
+<p> 
+<details>
+  <summary> 2. <span> On the structure of compact Kahler manifolds with nonnegative holomorphic sectional curvature, with Xi Zhang, <a href="https://arxiv.org/abs/2311.18779"> arXiv preprint:2311.18779v4</a>. </span> </summary>
+<p> The main result is the establishment of a "pseudoeffective" version of Bochner-type theorem, which leads to a splitting of the tangent bundle. 
+<p> The innovation point is an elegant integral inequality.
+<p> This is a key step of the structure theorems of HSC≥0 for the Kahler case obtained by <a href="https://arxiv.org/abs/2502.00367">Professor S. Matsumura</a> recently.</p>
+<p> Concerning the nonnegative holomorphic sectional curvature, it remains open whether it implies some minimality in AG?
+</details>
+  
+<p>
+  <details>
+    <summary> 1. Regularizing property of the twisted conical Kahler-Ricci flow, with with <a href="https://math.njust.edu.cn/43/dd/c17271a345053/page5.htm">Jiawei Liu</a> and Xi Zhang, <a href="https://arxiv.org/pdf/2406.08778">arxiv preprint</a>. </summary>
+<p> The primary contribution to this work belongs to my collaborators. The most significant guidance throughout my doctoral studies undoubtedly came from my supervisor, yet I wish to express my deepest personal gratitude to my senior, Jiawei Liu. 
+  During my difficult third year of PhD, I was grappling with the Kähler-Ricci flow. At that time, Jiawei had already graduated and was conducting his research in Germany. 
+  Despite the distance and his own commitments, he offered me patient and consistent guidance through our online correspondence.
+  That period culminated in a painful personal realization: that this particular field might not be the right path for me. The sense of frustration and doubt was significant. 
+  Yet, looking back, I see that this very struggle—and the generous, remote mentorship he provided across continents—was fundamental. 
+  It was through this process that I truly learned how to engage with a research problem, how to question, and how to begin.
+  </details>
+<hr>
+
+<h2> Notes </h2>
+  <details>
+  <summary> 2. <span> Partial positivity, rational dimension and Bochner-type results, in the appendix of F. Bei's preprint "<a href="https://arxiv.org/abs/2602.11002v2">Simply connectedness of Kähler and Riemannian manifolds via spectral estimates</a>".  </summary>
+  <p> A small remark.
+</details>
+<p> 
+
+<p>
+  <details>
+  <summary> 1. <span> (a four-page) Remark on quasi-negative k-Ricci curvature. <a href="https://arxiv.org/abs/2508.17237">arxiv preprint:2508.17237</a></span>  </summary>
+<p> This is just a note, I present an improvement on a result by Chu, Lee, and Tam based on a use of Gauss-Codazzi equation.
+<p> An example of a projective manifold with negative k-Ricci curvature admits an embedding of P^k was claimed in <a href="https://arxiv.org/abs/2011.13508">a paper by Li--Ni--Zhu</a>, this was in fact a typographical error. Thank Prof. Lei Ni for kind clarification.
+<p> I will not revise this paper until I have made sure of the existence of this example. If someone find such an example, it will be nice because it means that the study on negative k-Ricci curvature indeed provide new perspectives than negative holomorphic sectional curvature. I am not good at construting an example.
+</details>
+
+<hr>
+
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Clean up and modernize the homepage HTML structure by removing duplicated <head> sections and redundant inline styles. 
- Improve mobile/responsive behavior and add consistent site-wide styling. 
- Separate the long list of publications/talks into a dedicated `papers/` index to make the homepage concise and navigable.

### Description
- Simplified `index.html` by consolidating meta tags (`charset`, `viewport`), removing duplicate `<head>` blocks, and adding an inline stylesheet for typography and spacing. 
- Reorganized homepage content into a compact list with links to `papers/` and `Useful links/`, and moved detailed preprints/publications and talk entries to a new `papers/index.html`. 
- Added a new `papers/index.html` that contains the full list of preprints and publication details and retains MathJax configuration for math rendering on that page. 
- Fixed HTML document structure by ensuring a single `<html>`, `<head>`, and `<body>` block and cleaned up markup and links.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a007f66acf8832d838ad2718deb784f)