### PR TITLE
Add responsive site layout and shared stylesheet; refactor pages to new template

### DIFF
--- a/Seminar/Informal discussion in Complex Geometry.html
+++ b/Seminar/Informal discussion in Complex Geometry.html
@@ -1,118 +1,82 @@
 <html>
 <head>
-<title>Informal discussion in Complex geometry</title>
+  <title>Informal discussion in Complex Geometry</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../assets/site.css">
 </head>
-<body style="background-color:#e6f7ff;">
 
-<style>
-h1, h2, h3, h4, h5, h6 {
-    color: #483d8b;
-}
-a {
-    color: #483d8b;
-}
-</style>
+<body class="math-page">
+  <main class="site-shell">
+    <article class="site-card">
+      <header class="hero">
+        <div class="hero-heading">
+          <img class="github-avatar" src="https://github.com/BerkovichYu.png" alt="BerkovichYu GitHub avatar">
+          <h2 class="hero-title">Shiyu Zhang</h2>
+        </div>
+        <p class="subtitle">Informal discussion in Complex Geometry</p>
+        <nav class="top-nav" aria-label="Page navigation">
+          <a href="../">Home</a>
+          <a href="../papers/">Papers</a>
+          <a href="../conferences/">Talks</a>
+          <a href="../Useful%20links/">Useful links</a>
+        </nav>
+      </header>
 
-<h1>Informal discussion in Complex Geometry</h1>
-<p>
-    This is a small complex geometry group that meets once every two weeks, limited to a few young Chinese individuals, where we discuss specific topics of interest, share and check our recent ideas.
-<p>
-    When we conclude a seminar cycle, usually one cycle lasts at least a semester, the organizers will reorganize it and invite new members based on the current research interests.
-<p>
-    2025/03-2025/08, we are focusing on Parabolic Higgs bundles.
-<hr>
-    
-<h2>Schedule</h2>
-<details>  
- <summary> <b style="color:#800000"> The application of Hodge index Theorem on computating Chern classes. (张世宇) 2025/4/19 </b> </summary>
-  <blockquote>
-    Abstract: I will share my recent idea for nonabelian Hodge correspondence on Kahler klt varieties.
-  </blockquote>   
-</details>
-<p>
-    
-<details>  
- <summary> <b style="color:#800000"> The construction of canonical metrics for parabolic sheaves. (蒋天枢) 2025/4/5 </b> </summary>
-  <blockquote>
-    Abstract: Following my last talk, I will share with you my recent ideas on constructing a singular Hermitian metric on the regular part of 
-      a saturated reflexive parabolic sheaf whose curvature form will lead to the parabolic Chern characters. 
-  </blockquote>   
-</details>
-<p>
-    
-<details>
-  <summary> <b style="color:#800000"> Miyaoka-type inequality on minimal K\"ahler maifolds (张世宇) 2025/3/22 </b> </summary>
-  <blockquote>
-    Abstract: At the the first part, I give a proof for Miyaoka-type inequality for minimal K\"ahler manifolds based on the recent results by Cao, Ou and Paun. This is related to my recent work. At the second part, I give a proof on comparing the semi-stability of two torsion-free sheaves on the resolution of singularities.
-  </blockquote>
-<p>
-  <blockquote>
-      Bibiography:
-    <ol>
-        <li>
-            <a href="https://link.springer.com/article/10.1007/BF01444704" target="_blank">
-               <p>
-  <blockquote>
-      Bibiography:
-    <ol>
-        <li>
-            <a href="https://arxiv.org/abs/2501.18088" target="_blank">
-               W. Ou, A characterization of uniruled compact Kähler manifolds.
-            </a>   
-        </li>
-        <li>
-            <a href="https://arxiv.org/abs/2502.02183" target="_blank">
-                J. Cao and M. Paun, Remarks on Relative Canonical Bundles and Algebraicity Criteria for Foliations in Kähler context.
-            </a>
-            <br>
-        </li>
-    </ol>  
-  </blockquote>    
-            </a>   
-        </li>
-        <li>
-            <a href="https://projecteuclid.org/proceedings/advanced-studies-in-pure-mathematics/Algebraic-Geometry-Sendai-1985/Chapter/The-Chern-Classes-and-Kodaira-Dimension-of-a-Minimal-Variety/10.2969/aspm/01010449" target="_blank">
-               Y. Miyaoka, The Chern Classes and Kodaira Dimension of a Minimal Variety
-            </a>
-            <br>
-        </li>
-    </ol>  
-  </blockquote>    
-</details>
-<p>
-    
-<details>  
- <summary> <b style="color:#800000"> An introduction to parabolic sheaves. (蒋天枢) 2025/3/8 </b> </summary>
-  <blockquote>
-    Abstract: I will give a brief introduction to the category of parabolic sheaves.
-      Once you were familiar with the basic concepts. I will share my ideas of proving the Bogomolov-Gieseker inequality in
-      the parabolic setting.       
-  </blockquote>
-<p>
-  <blockquote>
-      Bibiography:
-    <ol>
-        <li>
-            <a href="https://link.springer.com/article/10.1007/BF01444704" target="_blank">
-               M. Maruyama and K. Yokogawa, Moduli of parabolic stable sheaves
-            </a>   
-        </li>
-        <li>
-            <a href="https://arxiv.org/abs/math/0411300" target="_blank">
-                T. Mochizuki, Kobayashi-Hitchin correspondence for tame harmonic bundles and an application
-            </a>
-            <br>
-        </li>
-    </ol>  
-  </blockquote>    
-</details>
-<p>
-    
-<details>
-  <summary> <b style="color:#800000"> The existence of Harder-Narasimhan filtration and the stability under a neighborhood of the nef class with rational coefficients. (张世宇) 2025/1/18 </b> </summary>
-  <blockquote>
-    Abstract: The proof of Kobayashi's result in his book (p. 161) is incomplete. [Bruasse, Harder-Narasimhan filtration on non-Kähler manifolds] addressed the gap by considering saturated subsheaves as weakly holomorphic maps. I will provide a relatively standard proof based on the more algebraic method introduced in [GKPT14, Reflexive differential forms on singular spaces, Appendix], and explain the statement regarding the stability of HN-filtration in a neighorhood of a nef cohomology class with rational coefficients, based on [Cao13, https://arxiv.org/abs/1305.4397]. Eventually, I could prove the existence of (w_1...w_{n-1})-Harder-Narasimhan filtration of torsion free sheaves on normal varities, where w_1,...w_{n-1} are nef classes, estabilish the concept of (w_1,...,w_{n-1})-HN-positivty, and prove a related vanishing theorem on normal varities with rational singularities.
-  </blockquote>
-</details>
+      <div class="content">
+        <section class="section">
+          <h2>About the seminar</h2>
+          <div class="news-card article-body">
+            <p>This is a small complex geometry group that meets once every two weeks, limited to a few young Chinese individuals, where we discuss specific topics of interest, share and check our recent ideas.</p>
+            <p>When we conclude a seminar cycle, usually one cycle lasts at least a semester, the organizers will reorganize it and invite new members based on the current research interests.</p>
+            <p>2025/03-2025/08, we are focusing on Parabolic Higgs bundles.</p>
+          </div>
+        </section>
 
-  
+        <section class="section">
+          <h2>Schedule</h2>
+          <details class="paper-entry">
+            <summary>The application of Hodge index Theorem on computating Chern classes. (张世宇) 2025/4/19</summary>
+            <blockquote>Abstract: I will share my recent idea for nonabelian Hodge correspondence on Kahler klt varieties.</blockquote>
+          </details>
+
+          <details class="paper-entry">
+            <summary>The construction of canonical metrics for parabolic sheaves. (蒋天枢) 2025/4/5</summary>
+            <blockquote>Abstract: Following my last talk, I will share with you my recent ideas on constructing a singular Hermitian metric on the regular part of a saturated reflexive parabolic sheaf whose curvature form will lead to the parabolic Chern characters.</blockquote>
+          </details>
+
+          <details class="paper-entry">
+            <summary>Miyaoka-type inequality on minimal K&quot;ahler maifolds (张世宇) 2025/3/22</summary>
+            <blockquote>Abstract: At the the first part, I give a proof for Miyaoka-type inequality for minimal K&quot;ahler manifolds based on the recent results by Cao, Ou and Paun. This is related to my recent work. At the second part, I give a proof on comparing the semi-stability of two torsion-free sheaves on the resolution of singularities.</blockquote>
+            <blockquote>
+              Bibiography:
+              <ol>
+                <li><a href="https://arxiv.org/abs/2501.18088" target="_blank">W. Ou, A characterization of uniruled compact Kähler manifolds.</a></li>
+                <li><a href="https://arxiv.org/abs/2502.02183" target="_blank">J. Cao and M. Paun, Remarks on Relative Canonical Bundles and Algebraicity Criteria for Foliations in Kähler context.</a></li>
+                <li><a href="https://projecteuclid.org/proceedings/advanced-studies-in-pure-mathematics/Algebraic-Geometry-Sendai-1985/Chapter/The-Chern-Classes-and-Kodaira-Dimension-of-a-Minimal-Variety/10.2969/aspm/01010449" target="_blank">Y. Miyaoka, The Chern Classes and Kodaira Dimension of a Minimal Variety.</a></li>
+              </ol>
+            </blockquote>
+          </details>
+
+          <details class="paper-entry">
+            <summary>An introduction to parabolic sheaves. (蒋天枢) 2025/3/8</summary>
+            <blockquote>Abstract: I will give a brief introduction to the category of parabolic sheaves. Once you were familiar with the basic concepts. I will share my ideas of proving the Bogomolov-Gieseker inequality in the parabolic setting.</blockquote>
+            <blockquote>
+              Bibiography:
+              <ol>
+                <li><a href="https://link.springer.com/article/10.1007/BF01444704" target="_blank">M. Maruyama and K. Yokogawa, Moduli of parabolic stable sheaves.</a></li>
+                <li><a href="https://arxiv.org/abs/math/0411300" target="_blank">T. Mochizuki, Kobayashi-Hitchin correspondence for tame harmonic bundles and an application.</a></li>
+              </ol>
+            </blockquote>
+          </details>
+
+          <details class="paper-entry">
+            <summary>The existence of Harder-Narasimhan filtration and the stability under a neighborhood of the nef class with rational coefficients. (张世宇) 2025/1/18</summary>
+            <blockquote>Abstract: The proof of Kobayashi's result in his book (p. 161) is incomplete. [Bruasse, Harder-Narasimhan filtration on non-Kähler manifolds] addressed the gap by considering saturated subsheaves as weakly holomorphic maps. I will provide a relatively standard proof based on the more algebraic method introduced in [GKPT14, Reflexive differential forms on singular spaces, Appendix], and explain the statement regarding the stability of HN-filtration in a neighorhood of a nef cohomology class with rational coefficients, based on [Cao13, https://arxiv.org/abs/1305.4397]. Eventually, I could prove the existence of (w_1...w_{n-1})-Harder-Narasimhan filtration of torsion free sheaves on normal varities, where w_1,...w_{n-1} are nef classes, estabilish the concept of (w_1,...,w_{n-1})-HN-positivty, and prove a related vanishing theorem on normal varities with rational singularities.</blockquote>
+          </details>
+        </section>
+      </div>
+    </article>
+  </main>
+</body>
+</html>

--- a/Teaching/Analysis 1/index.html
+++ b/Teaching/Analysis 1/index.html
@@ -1,59 +1,79 @@
 <html>
 <head>
-<title>Analyis 1</title>
+  <title>Analysis 1</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../../assets/site.css">
 </head>
-<body style="background-color:white;">
-  
-<p>
-  每周三晚更新作业情况和习题答案，如有问题可在微信上私信我。
-<p>
-  作业不打分，但是证明必须写严谨和提高可读性，这是检验你是否真正理解的重要标准。
-<p>
-<h2><a href="https://BerkovichYu.github.io/Teaching/Analysis 1/分析1 作业登记.xlsx">作业登记</a></h2>
-<h2>习题答案:</h2>
-<p>
-  • 12: <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/ODE.pdf">ODE:7,9,12</a>. <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution12.pdf">Solution 12</a>
-<p>
-  • 11: <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/series.pdf">series:7-11</a>. <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution11.pdf">Solution 11</a>
-<p>
-  • 10: <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/series.pdf">series:1,2,4,5,17</a>. <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution10.pdf">Solution 10</a>
-<p>
-  • 9: <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/ch14.pdf">ch14:偶数题</a>. <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution9.pdf">Solution 9</a>
-<p>
-  • 8: <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/ch13.pdf">chap13:1-7</a>. <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution8.pdf">Solution 8</a>
-<p>
-  • 7: <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/ch12.pdf">chap12奇数题</a>, <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution7.pdf">Solution 7</a>
-<p>
-  • 6: <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/chap11.pdf">chap11偶数题</a>, <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution6.pdf">Solution 6</a>
-<p>
-  • 5: 凸函数的性质，<a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution5.pdf">Solution 5</a>
-<p>
-  • 4: <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/ch10习题.pdf">奇数题</a>, <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution4.pdf">Solution 4</a>
-<p>
-  • 3: <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/ch9.pdf">1-10奇数题12-20偶数题</a>, <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution3.pdf">Solution 3</a>
-<p> 
-  • 2: <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Problem2.pdf">10-30偶数题</a>, <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution2.pdf">Solution 2</a>.
 
-<hr>
-Before 2022, I would serve as a teaching assistant every semester, taking on either an undergraduate or graduate course.
-  
-<p>
-  • 2022F: <a href="https://BerkovichYu.github.io/Teaching/Analysis 1">Analysis 1</a>.
-<p>
-  • 2022S: Riemann Surfaces.
-<p>
-  • 2021F: Analysis 3.
-<p>
-  • 2021S: Analysis 2.
-<p>
-  • 2020F: Analysis 1.
-<p>
-  • 2020S: Partial differential equations.
-<p>
-  • 2019F: Differential geometry of curves and surfaces.
-<p>
-  • 2018F: Ordinary differential equations.
-<p>
-  
+<body class="math-page">
+  <main class="site-shell">
+    <article class="site-card">
+      <header class="hero">
+        <div class="hero-heading">
+          <img class="github-avatar" src="https://github.com/BerkovichYu.png" alt="BerkovichYu GitHub avatar">
+          <h2 class="hero-title">Shiyu Zhang</h2>
+        </div>
+        <p class="subtitle">Analysis 1</p>
+        <nav class="top-nav" aria-label="Page navigation">
+          <a href="../../">Home</a>
+          <a href="../../papers/">Papers</a>
+          <a href="../../conferences/">Talks</a>
+          <a href="../../Useful%20links/">Useful links</a>
+        </nav>
+      </header>
+
+      <div class="content">
+        <section class="section">
+          <h2>Course notes</h2>
+          <div class="news-card article-body">
+            <p>每周三晚更新作业情况和习题答案，如有问题可在微信上私信我。</p>
+            <p>作业不打分，但是证明必须写严谨和提高可读性，这是检验你是否真正理解的重要标准。</p>
+          </div>
+        </section>
+
+        <section class="section">
+          <h2>Homework record</h2>
+          <a class="profile-link" href="https://BerkovichYu.github.io/Teaching/Analysis 1/分析1 作业登记.xlsx">
+            <strong>作业登记</strong>
+            <span>Homework registration spreadsheet.</span>
+            <em class="pill">XLSX</em>
+          </a>
+        </section>
+
+        <section class="section">
+          <h2>习题答案</h2>
+          <div class="resource-list">
+            <div class="resource-row"><strong>12.</strong> <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/ODE.pdf">ODE:7,9,12</a>. <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution12.pdf">Solution 12</a></div>
+            <div class="resource-row"><strong>11.</strong> <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/series.pdf">series:7-11</a>. <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution11.pdf">Solution 11</a></div>
+            <div class="resource-row"><strong>10.</strong> <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/series.pdf">series:1,2,4,5,17</a>. <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution10.pdf">Solution 10</a></div>
+            <div class="resource-row"><strong>9.</strong> <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/ch14.pdf">ch14:偶数题</a>. <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution9.pdf">Solution 9</a></div>
+            <div class="resource-row"><strong>8.</strong> <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/ch13.pdf">chap13:1-7</a>. <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution8.pdf">Solution 8</a></div>
+            <div class="resource-row"><strong>7.</strong> <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/ch12.pdf">chap12奇数题</a>, <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution7.pdf">Solution 7</a></div>
+            <div class="resource-row"><strong>6.</strong> <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/chap11.pdf">chap11偶数题</a>, <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution6.pdf">Solution 6</a></div>
+            <div class="resource-row"><strong>5.</strong> 凸函数的性质，<a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution5.pdf">Solution 5</a></div>
+            <div class="resource-row"><strong>4.</strong> <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/ch10习题.pdf">奇数题</a>, <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution4.pdf">Solution 4</a></div>
+            <div class="resource-row"><strong>3.</strong> <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/ch9.pdf">1-10奇数题12-20偶数题</a>, <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution3.pdf">Solution 3</a></div>
+            <div class="resource-row"><strong>2.</strong> <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Problem2.pdf">10-30偶数题</a>, <a href="https://BerkovichYu.github.io/Teaching/Analysis 1/Solution/Solution2.pdf">Solution 2</a>.</div>
+          </div>
+        </section>
+
+        <section class="section">
+          <h2>Teaching history</h2>
+          <p class="section-intro">Before 2022, I would serve as a teaching assistant every semester, taking on either an undergraduate or graduate course.</p>
+          <div class="card-grid">
+            <div class="entry-card"><p><strong>2022F:</strong> <a href="https://BerkovichYu.github.io/Teaching/Analysis 1">Analysis 1</a>.</p></div>
+            <div class="entry-card"><p><strong>2022S:</strong> Riemann Surfaces.</p></div>
+            <div class="entry-card"><p><strong>2021F:</strong> Analysis 3.</p></div>
+            <div class="entry-card"><p><strong>2021S:</strong> Analysis 2.</p></div>
+            <div class="entry-card"><p><strong>2020F:</strong> Analysis 1.</p></div>
+            <div class="entry-card"><p><strong>2020S:</strong> Partial differential equations.</p></div>
+            <div class="entry-card"><p><strong>2019F:</strong> Differential geometry of curves and surfaces.</p></div>
+            <div class="entry-card"><p><strong>2018F:</strong> Ordinary differential equations.</p></div>
+          </div>
+        </section>
+      </div>
+    </article>
+  </main>
 </body>
 </html>

--- a/Useful links/index.html
+++ b/Useful links/index.html
@@ -2,6 +2,8 @@
 <head>
   <title>Useful links</title>
   <meta name="google-site-verification" content="iiVqSYgyMZaSKjwBvW68iFKeEzjvsk_R_WuHS7sTOfA" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
   <script type="text/x-mathjax-config">
@@ -10,52 +12,64 @@
         messageStyle: "none"
     });
 </script>
+  <link rel="stylesheet" href="../assets/site.css">
 </head>
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document with Table of Contents</title>
-</head>
-  
-<head>
-    <style>
-        body {
-            padding-left: 30px;  /* 设置页面左边的空白 */
-        }
-    </style>
-</head>
+<body class="math-page">
+  <main class="site-shell">
+    <article class="site-card">
+      <header class="hero">
+        <div class="hero-heading">
+          <img class="github-avatar" src="https://github.com/BerkovichYu.png" alt="BerkovichYu GitHub avatar">
+          <h2 class="hero-title">Shiyu Zhang</h2>
+        </div>
+        <p class="subtitle">Useful links</p>
+        <nav class="top-nav" aria-label="Page navigation">
+          <a href="../">Home</a>
+          <a href="../papers/">Papers</a>
+          <a href="../conferences/">Talks</a>
+        </nav>
+      </header>
 
-<body style="background-color: #FFFFFF;">
-<style>
-h1, h2, h3, h4, h5 {
-  color: #333333; /* 浅黑色 */
-}
+      <div class="content">
+        <section class="section">
+          <h2>Views on Mathematics</h2>
+          <div class="entry-card">
+            <p><a href="https://arxiv.org/pdf/math/9404236">ON PROOF AND PROGRESS IN MATHEMATICS</a>, written by Thurston.</p>
+          </div>
+        </section>
 
-a {
-  color: #6495ED; /* 柔和的粉色 */
-}
-</style>
-I listed some useful links in practise.
+        <section class="section">
+          <h2>Mathematicians</h2>
+          <div class="entry-card">
+            <p><a href="https://BerkovichYu.github.io/Useful links/Hironaka.pdf">广中平祐先生访谈</a>.</p>
+          </div>
+        </section>
 
-<h3> Views on Mathematics
-<p>  <a href="https://arxiv.org/pdf/math/9404236">ON PROOF AND PROGRESS IN MATHEMATICS</a>, written by Thurston.
-<hr>
-  
-<h3> Mathematicians
-<p>  <a href="https://BerkovichYu.github.io/Useful links/Hironaka.pdf">广中平祐先生访谈</a>.
-<h3> Recommended textbooks for Undergraduate student</h3>
-<p> <a href="https://www.zhangjy9610.me/USTCdata.html">USTC Course Schedule Guide</a>. This is a set of course learning suggestions voluntarily compiled by graduates from the undergraduate mathematics program at USTC. Written in Chinese, it remains valuable to this day, even though the students' perspectives are somewhat limited.
-<h3> Recommended textbooks for Graduate student</h3>
-<p> <a href="https://masataka123.github.io/blog3/pdf/20251001_masterguide/master_guide_20251001_C2.pdf">教科書一覧</a>. 
-  I found this document on Professor Iwai's lab homepage. 
-  I think it could be extremely useful for graduate students interested in the intersection of several complex variables, complex geometry, and algebraic geometry.
-  The only catch is that it's written in Japanese. 
-</details>
-<hr>
-<h3> Illegal links to get published books or papers </h3>
-  Although I always obtain research literature through legitimate channels, university libraries often lack access to certain publishers. 
-  For instance, the University of Science and Technology of China does not have a subscription to download articles from the Proceedings of the AMS. 
-  It is also worth noting that for the Journal of Algebraic Geometry, papers published before 1992 are not available online and must be obtained as physical copies through the library.
-<p> <a href="https://libgen.vg/">Library Genesis</a>
-<p> <a href="https://www.sci-hub.pub/">Sci-hub.</a> 
+        <section class="section">
+          <h2>Recommended textbooks</h2>
+          <div class="card-grid">
+            <div class="info-card">
+              <h3>For undergraduate students</h3>
+              <p><a href="https://www.zhangjy9610.me/USTCdata.html">USTC Course Schedule Guide</a>. This is a set of course learning suggestions voluntarily compiled by graduates from the undergraduate mathematics program at USTC.</p>
+            </div>
+            <div class="info-card">
+              <h3>For graduate students</h3>
+              <p><a href="https://masataka123.github.io/blog3/pdf/20251001_masterguide/master_guide_20251001_C2.pdf">教科書一覧</a>. I found this document on Professor Iwai's lab homepage; it could be useful for graduate students interested in several complex variables, complex geometry, and algebraic geometry.</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="section">
+          <h2>Links to get published books or papers</h2>
+          <p class="section-intro">Although I always obtain research literature through legitimate channels, university libraries often lack access to certain publishers. For instance, the University of Science and Technology of China does not have a subscription to download articles from the Proceedings of the AMS. It is also worth noting that for the Journal of Algebraic Geometry, papers published before 1992 are not available online and must be obtained as physical copies through the library.</p>
+          <div class="card-grid">
+            <div class="entry-card"><p><a href="https://libgen.vg/">Library Genesis</a></p></div>
+            <div class="entry-card"><p><a href="https://www.sci-hub.pub/">Sci-hub</a></p></div>
+          </div>
+        </section>
+      </div>
+    </article>
+  </main>
+</body>
+</html>

--- a/Writting/Mathematics and World.html
+++ b/Writting/Mathematics and World.html
@@ -1,37 +1,43 @@
 <html>
 <head>
-<title>Mathematics and World</title>
+  <title>Mathematics and World</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../assets/site.css">
 </head>
-<body style="background-color:white;">
 
-<h2>Mathematics and World</h2>
-Since 2022, in order to achieve something and continue on the path of mathematics, I stopped considering anything outside of it.
-I enjoy teaching, reading science fiction, playing table tennis, and admiring a girl far away.
-Standing on the edge of a cliff, I felt I could no longer afford to think of anything else.
-I have worked hard to become an ordinary mathematician. Mathematics is important, but what has been lost is something far heavier.
-<p>
-Now, I often ask myself: what is the meaning of the mathematics I’ve spent so much time on? 
-Mathematics is a peculiar discipline, and only a small number of people truly advance mathematics that is meaningful to the world. 
-My research falls within the realm of complex geometry, but I feel that only a few people in the world are doing truly meaningful mathematics. 
-Everyone has different standards for what constitutes meaningful mathematics. My standard is whether the mathematical objects being studied are fundamental, and whether the framework is effective.
-Take the Poincaré Conjecture, for instance: a three-dimensional, simply connected, closed manifold is homeomorphic to a sphere. This is naturally a meaningful mathematical problem.
-Before Perelman solved the Poincaré Conjecture using Ricci flow, only a handful of people in the world were studying Ricci flow.
-Afterward, countless people published research on Ricci flow. I’ve skimmed through most of the literature, but it no longer seems important.
-Now, I have a different understanding of why Perelmann distanced himself from the mathematical community.
-After solving the Poincaré Conjecture, most mathematics seemed rather dull to him, and the ugly battles over fame and fortune only deepened his distaste.
-<p>
-As for the papers I’ve written, two of them concern curvature in differential geometry, based on questions posed by influential scholars in the field.
-But if you ask me what they’re truly worth, I don’t know. For me, working on these problems brought moments of inspiration, and I felt great joy when writing the paper on holomorphic sectional curvature.
-But fundamentally, the greatest impact of these two papers is that one gave me a solid result, and the other was written to fulfill my graduation requirements.
-Currently, I am focusing on geometric problems related to models that are central to the minimal model program.
-This feels more natural than the curvature problems I considered earlier because these are issues that inevitably arise.
-<p>
-Regardless, I hope to work on truly fundamental problems that I can wholeheartedly believe in.
-I am working towards this direction, but at this moment, the mathematics I’m engaged in doesn’t attract me any more than caring for a cat does.
-However, in a sense, mathematics is indeed not everything in life.
+<body class="math-page">
+  <main class="site-shell">
+    <article class="site-card">
+      <header class="hero">
+        <div class="hero-heading">
+          <img class="github-avatar" src="https://github.com/BerkovichYu.png" alt="BerkovichYu GitHub avatar">
+          <h2 class="hero-title">Shiyu Zhang</h2>
+        </div>
+        <p class="subtitle">Mathematics and World</p>
+        <nav class="top-nav" aria-label="Page navigation">
+          <a href="../">Home</a>
+          <a href="../papers/">Papers</a>
+          <a href="../conferences/">Talks</a>
+          <a href="../Useful%20links/">Useful links</a>
+        </nav>
+      </header>
 
-
-  
-
+      <div class="content">
+        <section class="section">
+          <h2>Mathematics and World</h2>
+          <div class="news-card article-body">
+            <p>Since 2022, in order to achieve something and continue on the path of mathematics, I stopped considering anything outside of it. I enjoy teaching, reading science fiction, playing table tennis, and admiring a girl far away. Standing on the edge of a cliff, I felt I could no longer afford to think of anything else. I have worked hard to become an ordinary mathematician. Mathematics is important, but what has been lost is something far heavier.</p>
+            <p>Now, I often ask myself: what is the meaning of the mathematics I’ve spent so much time on? Mathematics is a peculiar discipline, and only a small number of people truly advance mathematics that is meaningful to the world. My research falls within the realm of complex geometry, but I feel that only a few people in the world are doing truly meaningful mathematics. Everyone has different standards for what constitutes meaningful mathematics. My standard is whether the mathematical objects being studied are fundamental, and whether the framework is effective.</p>
+            <p>Take the Poincaré Conjecture, for instance: a three-dimensional, simply connected, closed manifold is homeomorphic to a sphere. This is naturally a meaningful mathematical problem. Before Perelman solved the Poincaré Conjecture using Ricci flow, only a handful of people in the world were studying Ricci flow. Afterward, countless people published research on Ricci flow. I’ve skimmed through most of the literature, but it no longer seems important.</p>
+            <p>Now, I have a different understanding of why Perelmann distanced himself from the mathematical community. After solving the Poincaré Conjecture, most mathematics seemed rather dull to him, and the ugly battles over fame and fortune only deepened his distaste.</p>
+            <p>As for the papers I’ve written, two of them concern curvature in differential geometry, based on questions posed by influential scholars in the field. But if you ask me what they’re truly worth, I don’t know. For me, working on these problems brought moments of inspiration, and I felt great joy when writing the paper on holomorphic sectional curvature. But fundamentally, the greatest impact of these two papers is that one gave me a solid result, and the other was written to fulfill my graduation requirements.</p>
+            <p>Currently, I am focusing on geometric problems related to models that are central to the minimal model program. This feels more natural than the curvature problems I considered earlier because these are issues that inevitably arise.</p>
+            <p>Regardless, I hope to work on truly fundamental problems that I can wholeheartedly believe in. I am working towards this direction, but at this moment, the mathematics I’m engaged in doesn’t attract me any more than caring for a cat does. However, in a sense, mathematics is indeed not everything in life.</p>
+          </div>
+        </section>
+      </div>
+    </article>
+  </main>
 </body>
 </html>

--- a/assets/site.css
+++ b/assets/site.css
@@ -1,0 +1,419 @@
+:root {
+  --page-bg: #eef2f7;
+  --panel-bg: #ffffff;
+  --ink: #20242f;
+  --muted: #5c6678;
+  --line: #cbd5e1;
+  --soft-line: #d7e0ec;
+  --chip-bg: #f7faff;
+  --blue: #2457a6;
+  --green: #26734d;
+  --gold: #8b6418;
+  --purple: #6550aa;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--page-bg);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
+  font-size: 18px;
+  line-height: 1.55;
+}
+
+body.math-page {
+  font-family: Georgia, "Times New Roman", serif;
+}
+
+a {
+  color: var(--blue);
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 3px;
+}
+
+a:hover {
+  color: var(--purple);
+}
+
+.site-shell {
+  max-width: 1180px;
+  margin: 42px auto;
+  padding: 0 24px;
+}
+
+.site-card {
+  background: var(--panel-bg);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: 10px 10px 0 rgba(148, 163, 184, 0.22);
+  overflow: hidden;
+}
+
+.hero {
+  padding: 40px 50px 28px;
+  border-bottom: 1px solid var(--soft-line);
+}
+
+.hero-heading {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.github-avatar {
+  width: clamp(54px, 7vw, 76px);
+  height: clamp(54px, 7vw, 76px);
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  background: var(--chip-bg);
+  object-fit: cover;
+}
+
+.hero-title {
+  margin: 0;
+  color: var(--ink);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(2.35rem, 4.4vw, 3.55rem);
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.subtitle {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: clamp(1.15rem, 2.2vw, 1.55rem);
+  line-height: 1.2;
+}
+
+.content {
+  padding: 38px 50px 50px;
+}
+
+.section {
+  border-top: 3px solid var(--line);
+  margin-top: 34px;
+  padding-top: 30px;
+}
+
+.section:first-child {
+  border-top: 0;
+  margin-top: 0;
+  padding-top: 0;
+}
+
+.section h2 {
+  margin: 0 0 16px;
+  color: var(--ink);
+  font-size: clamp(1.55rem, 3vw, 2.15rem);
+  line-height: 1.1;
+}
+
+.section-intro {
+  margin: 0 0 24px;
+  color: var(--muted);
+  font-size: 1.05rem;
+}
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--chip-bg);
+  padding: 4px 12px;
+  color: #273348;
+  font-size: 1rem;
+  line-height: 1.2;
+}
+
+.badge strong {
+  color: var(--ink);
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.card-grid.three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.info-card,
+.link-card,
+.news-card,
+.entry-card {
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: #fbfdff;
+  padding: 18px 20px;
+}
+
+.info-card h3,
+.news-card h3,
+.entry-card h3 {
+  margin: 0 0 8px;
+  color: var(--ink);
+  font-size: 1.16rem;
+  line-height: 1.2;
+}
+
+.info-card p,
+.news-card p,
+.entry-card p,
+.link-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.profile-link {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 24px;
+  margin-top: 18px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: #fbfdff;
+  padding: 16px 20px;
+  text-decoration: none;
+}
+
+.profile-link strong {
+  color: var(--purple);
+  font-size: 1.16rem;
+}
+
+.profile-link span {
+  color: var(--muted);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  background: #edf2f8;
+  padding: 2px 12px;
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.news-card {
+  padding: 18px 22px;
+}
+
+
+.homepage-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 240px;
+  gap: 34px;
+  align-items: start;
+}
+
+.main-column {
+  min-width: 0;
+}
+
+.about-section {
+  margin-top: 40px;
+}
+
+.research-section {
+  margin-top: 38px;
+}
+
+.sidebar-links {
+  border-left: 3px solid var(--line);
+  padding-left: 26px;
+  position: sticky;
+  top: 28px;
+}
+
+.sidebar-links h2 {
+  margin: 0 0 8px;
+  color: var(--ink);
+  font-size: 1.45rem;
+  line-height: 1.1;
+}
+
+.sidebar-links p {
+  margin: 0 0 18px;
+  color: var(--muted);
+  font-size: 0.98rem;
+}
+
+.side-link-list {
+  display: grid;
+  gap: 12px;
+}
+
+.side-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: #fbfdff;
+  padding: 14px 16px;
+  text-decoration: none;
+}
+
+.side-link strong {
+  font-size: 1.12rem;
+}
+
+.side-link.blue strong { color: var(--blue); }
+.side-link.green strong { color: var(--green); }
+.side-link.gold strong { color: var(--gold); }
+.side-link.purple strong { color: var(--purple); }
+
+.quick-links {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 20px;
+}
+
+.link-card {
+  display: flex;
+  min-height: 150px;
+  flex-direction: column;
+  justify-content: space-between;
+  color: inherit;
+  text-decoration: none;
+}
+
+.link-card strong {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 1.65rem;
+  line-height: 1.1;
+}
+
+.link-card.blue strong { color: var(--blue); }
+.link-card.green strong { color: var(--green); }
+.link-card.gold strong { color: var(--gold); }
+.link-card.purple strong { color: var(--purple); }
+
+.top-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 22px;
+}
+
+.top-nav a {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--chip-bg);
+  padding: 5px 12px;
+  color: var(--muted);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+details.entry-card,
+details.paper-entry {
+  display: block;
+  margin: 14px 0;
+}
+
+details.paper-entry {
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: #fbfdff;
+  padding: 16px 18px;
+}
+
+summary {
+  cursor: pointer;
+  color: var(--ink);
+  font-weight: 700;
+}
+
+details.paper-entry p {
+  color: var(--muted);
+}
+
+.list-card p {
+  margin: 0 0 14px;
+}
+
+@media (max-width: 760px) {
+  .site-shell {
+    margin: 20px auto;
+    padding: 0 12px;
+  }
+
+  .site-card {
+    box-shadow: 5px 5px 0 rgba(148, 163, 184, 0.2);
+  }
+
+  .hero,
+  .content {
+    padding-left: 22px;
+    padding-right: 22px;
+  }
+
+  .card-grid,
+  .card-grid.three,
+  .quick-links,
+  .profile-link,
+  .homepage-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar-links {
+    border-left: 0;
+    border-top: 3px solid var(--line);
+    padding-left: 0;
+    padding-top: 26px;
+    position: static;
+  }
+}
+
+.article-body {
+  color: #273348;
+}
+
+.article-body p {
+  margin: 0 0 16px;
+}
+
+.article-body blockquote {
+  margin: 12px 0 0;
+  border-left: 4px solid var(--line);
+  padding: 8px 0 8px 16px;
+  color: var(--muted);
+}
+
+.resource-list {
+  display: grid;
+  gap: 12px;
+}
+
+.resource-row {
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: #fbfdff;
+  padding: 12px 16px;
+}

--- a/conferences/index.html
+++ b/conferences/index.html
@@ -1,7 +1,9 @@
 <html>
 <head>
-  <title>Talks</title>
+  <title>Shiyu Zhang Talks</title>
   <meta name="google-site-verification" content="iiVqSYgyMZaSKjwBvW68iFKeEzjvsk_R_WuHS7sTOfA" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
   <script type="text/x-mathjax-config">
@@ -10,52 +12,44 @@
         messageStyle: "none"
     });
 </script>
+  <link rel="stylesheet" href="../assets/site.css">
 </head>
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document with Table of Contents</title>
-</head>
-  
-<head>
-    <style>
-        body {
-            padding-left: 30px;  /* 设置页面左边的空白 */
-        }
-    </style>
-</head>
+<body class="math-page">
+  <main class="site-shell">
+    <article class="site-card">
+      <header class="hero">
+        <div class="hero-heading">
+          <img class="github-avatar" src="https://github.com/BerkovichYu.png" alt="BerkovichYu GitHub avatar">
+          <h2 class="hero-title">Shiyu Zhang</h2>
+        </div>
+        <p class="subtitle">Talks and Conferences</p>
+        <nav class="top-nav" aria-label="Page navigation">
+          <a href="../">Home</a>
+          <a href="../papers/">Papers</a>
+          <a href="../Useful%20links/">Useful links</a>
+        </nav>
+      </header>
 
-<body style="background-color: #FFFFFF;">
-<style>
-h1, h2, h3, h4, h5 {
-  color: #333333; /* 浅黑色 */
-}
-
-a {
-  color: #6495ED; /* 柔和的粉色 */
-}
-</style>
-<h2>Invited talks</h2>
-  
-<p> 11. Nonabelian-Hodge correspondence over Kahler Log Terminal Varieties. <a href="https://u-lab.my-pharm.ac.jp/~noda/cnf/kanazawa31e.html">The 31th Symposium on Complex Geometry</a>. December, 2025. Kanazawa（金沢）, Japan.
-  
-<p> 10. Differential-Geometric Curvature Positivity and Rational Connectedness. Geometry&Topology Seminar at University of Science and Technology of China）. October, 2025. Shanghai（上海）, China.
-  
-<p> 9. Differential-Geometric Curvature Positivity and Rational Connectedness. Geometric analysis seminar at Westlake University. October, 2025. Hangzhou（杭州）, China.
-
-<p> 8. Compact Kahler manifolds with partially semi-positive curvature. Young Geometric Analysis Forum. June, 2025. Xiamen Univeristy（厦门大学）.
-  
-<p> 7. The Miyaoka-Yau inequality for minimal Kahler klt spaces. Young Geometric Forum at Nanjing University of Science and Technology（南京理工大学）. July, 2025. Nanjing（南京）, China.
-  
-<p> 6. Compact Kahler manifolds with partially semi-positive curvature. March, 2025. Zhejiang Normal Univeristy（浙江师范大学）, Jinhua.
-
-<p> 5. On Structure of Compact Kähler Manifolds with Nonnegative Holomorphic Sectional Curvature. <a href="https://www.math.pku.edu.cn/teachers/jianchunchu/seminar24-25Fall.html">Geometric Analysis Seminar at BICMR</a>. September, 2024. Online.
-  
-<p> 4. A Bochner-type formula for nonnegative holomorphic sectional curvature. <a href="https://www.math.is.tohoku.ac.jp/~sugawa/ICFIDCAA2024/">30th International Conference on Finite or Infinite Dimensional Complex Analysis and Applications (ICFIDCAA 2024)</a>. August, 2024. Tohoku University, Sendai.
-  
-<p> 3. On the structure of compact K\"ahler manifolds with semi-positive holomorphic sectional curvature. <a href="http://conference.bicmr.pku.edu.cn/meeting/index?id=117">Workshop on Geometric Analysis 2024</a>. July, 2024. Inner Mongolia University, Inner Mongolia（内蒙古）, China.
-  
-<p> 2. Compact K\"ahler manifolds with quasi-positive holomorphic sectional curvature. Zhejiang Normal University, Jinhua（金华）, China. April 2024.
-
-<p> 1. Compact K\"ahler manifolds with quasi-positive holomorphic sectional curvature. Geometry&Topology Seminar（几何拓扑研讨会）, University of Science and Technology of China, April 2024.
+      <div class="content">
+        <section class="section">
+          <h2>Invited talks</h2>
+          <div class="list-card">
+            <div class="entry-card"><p><strong>11.</strong> Nonabelian-Hodge correspondence over Kahler Log Terminal Varieties. <a href="https://u-lab.my-pharm.ac.jp/~noda/cnf/kanazawa31e.html">The 31th Symposium on Complex Geometry</a>. December, 2025. Kanazawa（金沢）, Japan.</p></div>
+            <div class="entry-card"><p><strong>10.</strong> Differential-Geometric Curvature Positivity and Rational Connectedness. Geometry&amp;Topology Seminar at University of Science and Technology of China. October, 2025. Shanghai（上海）, China.</p></div>
+            <div class="entry-card"><p><strong>9.</strong> Differential-Geometric Curvature Positivity and Rational Connectedness. Geometric analysis seminar at Westlake University. October, 2025. Hangzhou（杭州）, China.</p></div>
+            <div class="entry-card"><p><strong>8.</strong> Compact Kahler manifolds with partially semi-positive curvature. Young Geometric Analysis Forum. June, 2025. Xiamen Univeristy（厦门大学）.</p></div>
+            <div class="entry-card"><p><strong>7.</strong> The Miyaoka-Yau inequality for minimal Kahler klt spaces. Young Geometric Forum at Nanjing University of Science and Technology（南京理工大学）. July, 2025. Nanjing（南京）, China.</p></div>
+            <div class="entry-card"><p><strong>6.</strong> Compact Kahler manifolds with partially semi-positive curvature. March, 2025. Zhejiang Normal Univeristy（浙江师范大学）, Jinhua.</p></div>
+            <div class="entry-card"><p><strong>5.</strong> On Structure of Compact Kähler Manifolds with Nonnegative Holomorphic Sectional Curvature. <a href="https://www.math.pku.edu.cn/teachers/jianchunchu/seminar24-25Fall.html">Geometric Analysis Seminar at BICMR</a>. September, 2024. Online.</p></div>
+            <div class="entry-card"><p><strong>4.</strong> A Bochner-type formula for nonnegative holomorphic sectional curvature. <a href="https://www.math.is.tohoku.ac.jp/~sugawa/ICFIDCAA2024/">30th International Conference on Finite or Infinite Dimensional Complex Analysis and Applications (ICFIDCAA 2024)</a>. August, 2024. Tohoku University, Sendai.</p></div>
+            <div class="entry-card"><p><strong>3.</strong> On the structure of compact K\"ahler manifolds with semi-positive holomorphic sectional curvature. <a href="http://conference.bicmr.pku.edu.cn/meeting/index?id=117">Workshop on Geometric Analysis 2024</a>. July, 2024. Inner Mongolia University, Inner Mongolia（内蒙古）, China.</p></div>
+            <div class="entry-card"><p><strong>2.</strong> Compact K\"ahler manifolds with quasi-positive holomorphic sectional curvature. Zhejiang Normal University, Jinhua（金华）, China. April 2024.</p></div>
+            <div class="entry-card"><p><strong>1.</strong> Compact K\"ahler manifolds with quasi-positive holomorphic sectional curvature. Geometry&amp;Topology Seminar（几何拓扑研讨会）, University of Science and Technology of China, April 2024.</p></div>
+          </div>
+        </section>
+      </div>
+    </article>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -2,152 +2,95 @@
 <head>
   <title>Shiyu Zhang Complex Geometry</title>
   <meta name="google-site-verification" content="iiVqSYgyMZaSKjwBvW68iFKeEzjvsk_R_WuHS7sTOfA" />
-  <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
-</script>
-  <script type="text/x-mathjax-config">
-    MathJax.Hub.Config({
-        tex2jax: {inlineMath: [['$', '$']]},
-        messageStyle: "none"
-    });
-</script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="assets/site.css">
 </head>
 
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document with Table of Contents</title>
-</head>
-  
-<head>
-    <style>
-        body {
-            padding-left: 30px;  /* 设置页面左边的空白 */
-        }
-    </style>
-</head>
+<body>
+  <main class="site-shell">
+    <article class="site-card">
+      <header class="hero">
+        <div class="hero-heading">
+          <img class="github-avatar" src="https://github.com/BerkovichYu.png" alt="BerkovichYu GitHub avatar">
+          <h2 class="hero-title">Shiyu Zhang</h2>
+        </div>
+        <p class="subtitle">Complex Geometry</p>
+      </header>
 
-<body style="background-color: #FFFFFF;">
-<style>
-h1, h2, h3, h4, h5 {
-  color: #333333; /* 浅黑色 */
-}
+      <div class="content homepage-layout">
+        <div class="main-column">
+          <section class="section" aria-label="Profile">
+            <ul class="badges">
+              <li class="badge"><strong>Researcher</strong> Mathematics, China</li>
+              <li class="badge"><strong>B.S.</strong> USTC, June 2020</li>
+              <li class="badge"><strong>Ph.D.</strong> USTC, June 2026</li>
+              <li class="badge"><strong>Email</strong> shiyu123@mail.ustc.edu.cn</li>
+              <li class="badge"><strong>Born</strong> March 1999, China</li>
+            </ul>
+          </section>
 
-a {
-  color: #6495ED; /* 柔和的粉色 */
-}
-</style>
-<h1>Shiyu Zhang</h1>
-<p>
-<b>About me</b>：I am a researcher in mathematics from China. You can find me by email "shiyu123@mail.ustc.edu.cn".
-<p>
- <b>Gender</b>: Male &nbsp; <b>Born</b>: March, 1999, China
-<p>
-<b>Education</b>:  I received my B.S. (June 2020) and Ph.D. (June 2026, advisor: Xi Zhang) in Mathematics from University of Science and Technology of China (USTC).
-<p>
-<b>Research</b>:  My previous research has primarily focused on the following specific topics, investigated using analytic methods:
-  <p> &middot Higgs sheaves over singular varieties and related geometric applications;
-  <p> &middot The relationship between rational connectedness and semi-positive differential-geometric curvature.
-<hr>
+          <section class="section about-section">
+            <h2>About me</h2>
+            <div class="news-card">
+              <p>I am a researcher in mathematics from China. I received my B.S. (June 2020) and Ph.D. (June 2026, advisor: Xi Zhang) in Mathematics from University of Science and Technology of China (USTC).</p>
+            </div>
+          </section>
 
-<h2>Latest talks and conferences (<a href="https://BerkovichYu.github.io/conferences">More)</a></h2>
-<p>
-  <details>
-  <summary>Non-abelian Hodge correspondence and the Miyaoka-Yau equality over singular varieties, Workshop on Geometric Analysis 2026, PhD student report, May 24-29, 珠海</summary>
-  <p>
-    I will talk about recent work [5, 6].
-  </p>
-  </details>
-</p>
+          <section class="section research-section">
+            <h2>Research</h2>
+            <p class="section-intro">My previous research has primarily focused on the following specific topics, investigated using analytic methods.</p>
+            <div class="card-grid">
+              <div class="info-card">
+                <h3>Higgs sheaves over singular varieties</h3>
+                <p>Higgs sheaves, singular spaces, and related geometric applications.</p>
+              </div>
+              <div class="info-card">
+                <h3>Curvature and rational connectedness</h3>
+                <p>The relationship between rational connectedness and semi-positive differential-geometric curvature.</p>
+              </div>
+            </div>
+            <a class="profile-link" href="https://scholar.google.com/citations?hl=en&amp;user=x2xD6cAAAAAJ&amp;view_op=list_works&amp;sortby=pubdate">
+              <strong>Google Scholar</strong>
+              <span>Citation profile and publication list.</span>
+              <em class="pill">Profile</em>
+            </a>
+          </section>
 
-<hr>
-  
-<h2 id="Preprints">Preprints and Publications (<a href="https://scholar.google.com/citations?hl=en&user=x2xD6cAAAAAJ&view_op=list_works&sortby=pubdate">Google Scholar</a>)</h2>
-Presented in chronological order with summaries and remarks (please click title).
-<p>
-<details>
-  <summary> 6. <span> Non-abelian Hodge corrrespondence over singular K\"ahler spaces, with Chuanjing Zhang and Xi Zhang, <a href="https://arxiv.org/abs/2601.13071"> arxiv preprint:2601.12071</a>. </span> </summary>
-<p> 
-  In this paper, we establish the nonabelian Hodge correspondence over compact K\"ahler klt spaces as well as their regular loci, thereby generalizing the previous result of Greb-Kebekus-Peternell-Taji for projective klt varieties.
-<p> As an interesting application, we prove that if a projective klt variety with big canonical divisor satisfies the orbifold Miyaoka-Yau type equality in the sense of the previous work [5] joint with M. Iwai and S. Jinnouchi, then its canonical model must be a singular quotient of the unit ball. 
-  See also Jinnouchi's <a href="https://arxiv.org/abs/2512.24161"> recent preprint</a> for K-stable klt varieties with big anti-canonical divisor. 
-  Toghther, these results confirm the Miyaoka-Yau inequality formulated via non-pluripolar product developed in the paper [5] provide an effective criterion for projective klt varieties with big canonical divisor.
-</details>
-<p>
-  
-<p>
-<details>
-  <summary> 5. <span> Miyaoka-Yau inequality for singular varieties with big canonical or anticanonical divisor. with <a href="https://masataka123.github.io/blog3_e/">Masataka Iwai</a> and Satoshi Jinnouchi, <a href="https://arxiv.org/abs/2507.08522">arxiv preprint:2507.08522v2</a>. </span> </summary>
-<p> The main result is establishing the Miyaoka-Yau inequality for projective klt varieties with big canonical divisor.
-<p> The basic idea is proving Bogomolov-Gieseker inequality formulated via the non-pluripolar product. When I discussed with M. Iwai how to extend it to the klt case, I contributed this work. 
-<p> A basic question is characterizing the equality case of Bogomolov-Gieseker inequality. It's subtle because we used the limiting process in the proof.
-</details>
-<p>
+          <section class="section">
+            <h2>News</h2>
+            <div class="news-card">
+              <h3>Non-abelian Hodge correspondence and the Miyaoka-Yau equality over singular varieties</h3>
+              <p>Workshop on Geometric Analysis 2026, PhD student report, May 24-29, 珠海.</p>
+              <p>I will talk about recent work [5, 6].</p>
+            </div>
+          </section>
+        </div>
 
-<details>
-  <summary> 4. <span> Compact Kahler manifolds with partially semi-positive curvature, with Xi Zhang, <a href="https://arxiv.org/abs/2504.13155"></a> to appear in the Transactions of the American Mathematical Society. </span> </summary>
-<p>  Our first main result provides a new differential-geometric criterion for rational connectedness. We prove that a compact Kähler manifold is rationally connected if and only if its tangent bundle is BC-p positive for every p≥1. 
-     This notion of BC-p positivity is very weak and arises naturally from a Bochner-type formula associated with MRC fibrations (Proposition 3.3). 
-<p>  As a direct application, we confirm a conjecture of Prof. Lei Ni, showing that positive orthogonal Ricci curvature implies rational connectedness.
-<p>  Our second result establishes structure theorems for manifolds with semi-positive immediate curvature conditions, offering a natural generalization of several classical works.
-<p>  It would be interesting whether BC-p quasi-positivity (p≥1) imply the rational connectedness and BC-2 quasi-positivity implies the projectivity. 
-     The latter is posed by L. Ni. The former is posed by me and indeed implies a conjecture of Xiaokui Yang that quasi-positive uniformly RC-positivity ensures the rational connectedness. 
-<p>  I am grateful to Prof. Lei Ni for his attention to this work, and for his generous assistance on numerous other occasions.
-<p>  On a personal note, I must candidly share that the first version of this paper contained an error—specifically, a mistaken equality in a key integral inequality. 
-     It was the reviewer’s careful reading that patiently pointed out this issue. 
-     In the process of carefully revising those details, I discovered something new and came to a deeper understanding: mathematics is not only about grand visions and directions, but also emerges from meticulous attention to detail. 
-     We must take full responsibility for what we write.
-</details>
-<p>
-  
-<details>
-  <summary> 3. <span> The Miyaoka-Yau inequality on minimal Kahler spaces, with Chuanjing Zhang and Xi Zhang <a href="https://arxiv.org/abs/2503.13365">arXiv preprint:2503.13365</a>. </span> </summary>
-<p>  We extend the classical Miyaoka-Yau inequality to all minimal K\"ahler klt spaces.
-<p>  One key is the existence of orbifold modification by <a href="https://arxiv.org/abs/2512.20708">Kollar and Ou</a> for klt spaces. 
-<p>  This paper does provide a relatively general approach to considering Chern number inequalities and computing HN types of Higgs sheaves on K\"ahler KLT varieties.
-<p>  On the other hand, our argument is new for the smooth case. After completing this paper, Iwai shared an alternative approach with me. Please see the paper [5]. 
-<p>  Notably, the framework developed here—based on L^p approximate Hermitian–Einstein metrics—yields an important byproduct: 
-     we obtain the semistability (respectively, generic nefness) of torsion-free sheaves under symmetric powers, exterior powers, and tensor products in the singular setting.
-<p>  Finally, I should acknowledge that the first version of this paper contained an insufficient discussion of Harder–Narasimhan filtrations on singular varieties,
-     due to my then-unfamiliarity with certain technical aspects. That exposition was consequently difficult to follow; the present version supersedes it entirely.
-</details>
-<p>
-
-<p> 
-<details>
-  <summary> 2. <span> On the structure of compact Kahler manifolds with nonnegative holomorphic sectional curvature, with Xi Zhang, <a href="https://arxiv.org/abs/2311.18779"> arXiv preprint:2311.18779v4</a>. </span> </summary>
-<p> The main result is the establishment of a "pseudoeffective" version of Bochner-type theorem, which leads to a splitting of the tangent bundle. 
-<p> The innovation point is an elegant integral inequality.
-<p> This is a key step of the structure theorems of HSC≥0 for the Kahler case obtained by <a href="https://arxiv.org/abs/2502.00367">Professor S. Matsumura</a> recently.</p>
-<p> Concerning the nonnegative holomorphic sectional curvature, it remains open whether it implies some minimality in AG?
-</details>
-  
-<p>
-  <details>
-    <summary> 1. Regularizing property of the twisted conical Kahler-Ricci flow, with with <a href="https://math.njust.edu.cn/43/dd/c17271a345053/page5.htm">Jiawei Liu</a> and Xi Zhang, <a href="https://arxiv.org/pdf/2406.08778">arxiv preprint</a>. </summary>
-<p> The primary contribution to this work belongs to my collaborators. The most significant guidance throughout my doctoral studies undoubtedly came from my supervisor, yet I wish to express my deepest personal gratitude to my senior, Jiawei Liu. 
-  During my difficult third year of PhD, I was grappling with the Kähler-Ricci flow. At that time, Jiawei had already graduated and was conducting his research in Germany. 
-  Despite the distance and his own commitments, he offered me patient and consistent guidance through our online correspondence.
-  That period culminated in a painful personal realization: that this particular field might not be the right path for me. The sense of frustration and doubt was significant. 
-  Yet, looking back, I see that this very struggle—and the generous, remote mentorship he provided across continents—was fundamental. 
-  It was through this process that I truly learned how to engage with a research problem, how to question, and how to begin.
-  </details>
-<hr>
-
-<h2> Notes </h2>
-  <details>
-  <summary> 2. <span> Partial positivity, rational dimension and Bochner-type results, in the appendix of F. Bei's preprint "<a href="https://arxiv.org/abs/2602.11002v2">Simply connectedness of Kähler and Riemannian manifolds via spectral estimates</a>".  </summary>
-  <p> A small remark.
-</details>
-<p> 
-
-<p>
-  <details>
-  <summary> 1. <span> (a four-page) Remark on quasi-negative k-Ricci curvature. <a href="https://arxiv.org/abs/2508.17237">arxiv preprint:2508.17237</a></span>  </summary>
-<p> This is just a note, I present an improvement on a result by Chu, Lee, and Tam based on a use of Gauss-Codazzi equation.
-<p> An example of a projective manifold with negative k-Ricci curvature admits an embedding of P^k was claimed in <a href="https://arxiv.org/abs/2011.13508">a paper by Li--Ni--Zhu</a>, this was in fact a typographical error. Thank Prof. Lei Ni for kind clarification.
-<p> I will not revise this paper until I have made sure of the existence of this example. If someone find such an example, it will be nice because it means that the study on negative k-Ricci curvature indeed provide new perspectives than negative holomorphic sectional curvature. I am not good at construting an example.
-</details>
-
-<hr>
-<h2> <a href="https://BerkovichYu.github.io/Useful links">Collected articles </a> </h2>  
-<hr>
+        <aside class="sidebar-links" aria-label="Quick links">
+          <h2>Quick links</h2>
+          <p>Compact navigation for papers, talks, teaching, and references.</p>
+          <nav class="side-link-list">
+            <a class="side-link blue" href="papers/">
+              <strong>Papers</strong>
+              <em class="pill">Research</em>
+            </a>
+            <a class="side-link green" href="conferences/">
+              <strong>Talks</strong>
+              <em class="pill">Updates</em>
+            </a>
+            <a class="side-link gold" href="Useful%20links/">
+              <strong>Useful links</strong>
+              <em class="pill">Notes</em>
+            </a>
+            <a class="side-link purple" href="Teaching/Analysis%201/">
+              <strong>Teaching</strong>
+              <em class="pill">Course</em>
+            </a>
+          </nav>
+        </aside>
+      </div>
+    </article>
+  </main>
+</body>
+</html>

--- a/papers/index.html
+++ b/papers/index.html
@@ -1,0 +1,128 @@
+<html>
+<head>
+  <title>Shiyu Zhang Papers</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+</script>
+  <script type="text/x-mathjax-config">
+    MathJax.Hub.Config({
+        tex2jax: {inlineMath: [['$', '$']]},
+        messageStyle: "none"
+    });
+</script>
+  <link rel="stylesheet" href="../assets/site.css">
+</head>
+
+<body class="math-page">
+  <main class="site-shell">
+    <article class="site-card">
+      <header class="hero">
+        <div class="hero-heading">
+          <img class="github-avatar" src="https://github.com/BerkovichYu.png" alt="BerkovichYu GitHub avatar">
+          <h2 class="hero-title">Shiyu Zhang</h2>
+        </div>
+        <p class="subtitle">Papers and Notes</p>
+        <nav class="top-nav" aria-label="Page navigation">
+          <a href="../">Home</a>
+          <a href="../conferences/">Talks</a>
+          <a href="../Useful%20links/">Useful links</a>
+        </nav>
+      </header>
+
+      <div class="content">
+<section class="section"><h2 id="Preprints">Preprints and Publications (<a href="https://scholar.google.com/citations?hl=en&user=x2xD6cAAAAAJ&view_op=list_works&sortby=pubdate">Google Scholar</a>)</h2>
+<p class="section-intro">Presented in chronological order with summaries and remarks (please click title).</p>
+<p>
+<details class="paper-entry">
+  <summary> 6. <span> Non-abelian Hodge corrrespondence over singular K\"ahler spaces, with Chuanjing Zhang and Xi Zhang, <a href="https://arxiv.org/abs/2601.13071"> arxiv preprint:2601.12071</a>. </span> </summary>
+<p> 
+  In this paper, we establish the nonabelian Hodge correspondence over compact K\"ahler klt spaces as well as their regular loci, thereby generalizing the previous result of Greb-Kebekus-Peternell-Taji for projective klt varieties.
+<p> As an interesting application, we prove that if a projective klt variety with big canonical divisor satisfies the orbifold Miyaoka-Yau type equality in the sense of the previous work [5] joint with M. Iwai and S. Jinnouchi, then its canonical model must be a singular quotient of the unit ball. 
+  See also Jinnouchi's <a href="https://arxiv.org/abs/2512.24161"> recent preprint</a> for K-stable klt varieties with big anti-canonical divisor. 
+  Toghther, these results confirm the Miyaoka-Yau inequality formulated via non-pluripolar product developed in the paper [5] provide an effective criterion for projective klt varieties with big canonical divisor.
+</details>
+<p>
+  
+<p>
+<details class="paper-entry">
+  <summary> 5. <span> Miyaoka-Yau inequality for singular varieties with big canonical or anticanonical divisor. with <a href="https://masataka123.github.io/blog3_e/">Masataka Iwai</a> and Satoshi Jinnouchi, <a href="https://arxiv.org/abs/2507.08522">arxiv preprint:2507.08522v2</a>. </span> </summary>
+<p> The main result is establishing the Miyaoka-Yau inequality for projective klt varieties with big canonical divisor.
+<p> The basic idea is proving Bogomolov-Gieseker inequality formulated via the non-pluripolar product. When I discussed with M. Iwai how to extend it to the klt case, I contributed this work. 
+<p> A basic question is characterizing the equality case of Bogomolov-Gieseker inequality. It's subtle because we used the limiting process in the proof.
+</details>
+<p>
+
+<details class="paper-entry">
+  <summary> 4. <span> Compact Kahler manifolds with partially semi-positive curvature, with Xi Zhang, <a href="https://arxiv.org/abs/2504.13155"></a> to appear in the Transactions of the American Mathematical Society. </span> </summary>
+<p>  Our first main result provides a new differential-geometric criterion for rational connectedness. We prove that a compact Kähler manifold is rationally connected if and only if its tangent bundle is BC-p positive for every p≥1. 
+     This notion of BC-p positivity is very weak and arises naturally from a Bochner-type formula associated with MRC fibrations (Proposition 3.3). 
+<p>  As a direct application, we confirm a conjecture of Prof. Lei Ni, showing that positive orthogonal Ricci curvature implies rational connectedness.
+<p>  Our second result establishes structure theorems for manifolds with semi-positive immediate curvature conditions, offering a natural generalization of several classical works.
+<p>  It would be interesting whether BC-p quasi-positivity (p≥1) imply the rational connectedness and BC-2 quasi-positivity implies the projectivity. 
+     The latter is posed by L. Ni. The former is posed by me and indeed implies a conjecture of Xiaokui Yang that quasi-positive uniformly RC-positivity ensures the rational connectedness. 
+<p>  I am grateful to Prof. Lei Ni for his attention to this work, and for his generous assistance on numerous other occasions.
+<p>  On a personal note, I must candidly share that the first version of this paper contained an error—specifically, a mistaken equality in a key integral inequality. 
+     It was the reviewer’s careful reading that patiently pointed out this issue. 
+     In the process of carefully revising those details, I discovered something new and came to a deeper understanding: mathematics is not only about grand visions and directions, but also emerges from meticulous attention to detail. 
+     We must take full responsibility for what we write.
+</details>
+<p>
+  
+<details class="paper-entry">
+  <summary> 3. <span> The Miyaoka-Yau inequality on minimal Kahler spaces, with Chuanjing Zhang and Xi Zhang <a href="https://arxiv.org/abs/2503.13365">arXiv preprint:2503.13365</a>. </span> </summary>
+<p>  We extend the classical Miyaoka-Yau inequality to all minimal K\"ahler klt spaces.
+<p>  One key is the existence of orbifold modification by <a href="https://arxiv.org/abs/2512.20708">Kollar and Ou</a> for klt spaces. 
+<p>  This paper does provide a relatively general approach to considering Chern number inequalities and computing HN types of Higgs sheaves on K\"ahler KLT varieties.
+<p>  On the other hand, our argument is new for the smooth case. After completing this paper, Iwai shared an alternative approach with me. Please see the paper [5]. 
+<p>  Notably, the framework developed here—based on L^p approximate Hermitian–Einstein metrics—yields an important byproduct: 
+     we obtain the semistability (respectively, generic nefness) of torsion-free sheaves under symmetric powers, exterior powers, and tensor products in the singular setting.
+<p>  Finally, I should acknowledge that the first version of this paper contained an insufficient discussion of Harder–Narasimhan filtrations on singular varieties,
+     due to my then-unfamiliarity with certain technical aspects. That exposition was consequently difficult to follow; the present version supersedes it entirely.
+</details>
+<p>
+
+<p> 
+<details class="paper-entry">
+  <summary> 2. <span> On the structure of compact Kahler manifolds with nonnegative holomorphic sectional curvature, with Xi Zhang, <a href="https://arxiv.org/abs/2311.18779"> arXiv preprint:2311.18779v4</a>. </span> </summary>
+<p> The main result is the establishment of a "pseudoeffective" version of Bochner-type theorem, which leads to a splitting of the tangent bundle. 
+<p> The innovation point is an elegant integral inequality.
+<p> This is a key step of the structure theorems of HSC≥0 for the Kahler case obtained by <a href="https://arxiv.org/abs/2502.00367">Professor S. Matsumura</a> recently.</p>
+<p> Concerning the nonnegative holomorphic sectional curvature, it remains open whether it implies some minimality in AG?
+</details>
+  
+<p>
+  <details class="paper-entry">
+    <summary> 1. Regularizing property of the twisted conical Kahler-Ricci flow, with with <a href="https://math.njust.edu.cn/43/dd/c17271a345053/page5.htm">Jiawei Liu</a> and Xi Zhang, <a href="https://arxiv.org/pdf/2406.08778">arxiv preprint</a>. </summary>
+<p> The primary contribution to this work belongs to my collaborators. The most significant guidance throughout my doctoral studies undoubtedly came from my supervisor, yet I wish to express my deepest personal gratitude to my senior, Jiawei Liu. 
+  During my difficult third year of PhD, I was grappling with the Kähler-Ricci flow. At that time, Jiawei had already graduated and was conducting his research in Germany. 
+  Despite the distance and his own commitments, he offered me patient and consistent guidance through our online correspondence.
+  That period culminated in a painful personal realization: that this particular field might not be the right path for me. The sense of frustration and doubt was significant. 
+  Yet, looking back, I see that this very struggle—and the generous, remote mentorship he provided across continents—was fundamental. 
+  It was through this process that I truly learned how to engage with a research problem, how to question, and how to begin.
+  </details>
+</section>
+
+<section class="section">
+<h2>Notes</h2>
+  <details class="paper-entry">
+  <summary> 2. <span> Partial positivity, rational dimension and Bochner-type results, in the appendix of F. Bei's preprint "<a href="https://arxiv.org/abs/2602.11002v2">Simply connectedness of Kähler and Riemannian manifolds via spectral estimates</a>".  </summary>
+  <p> A small remark.
+</details>
+<p> 
+
+<p>
+  <details class="paper-entry">
+  <summary> 1. <span> (a four-page) Remark on quasi-negative k-Ricci curvature. <a href="https://arxiv.org/abs/2508.17237">arxiv preprint:2508.17237</a></span>  </summary>
+<p> This is just a note, I present an improvement on a result by Chu, Lee, and Tam based on a use of Gauss-Codazzi equation.
+<p> An example of a projective manifold with negative k-Ricci curvature admits an embedding of P^k was claimed in <a href="https://arxiv.org/abs/2011.13508">a paper by Li--Ni--Zhu</a>, this was in fact a typographical error. Thank Prof. Lei Ni for kind clarification.
+<p> I will not revise this paper until I have made sure of the existence of this example. If someone find such an example, it will be nice because it means that the study on negative k-Ricci curvature indeed provide new perspectives than negative holomorphic sectional curvature. I am not good at construting an example.
+</details>
+
+</section>
+
+      </div>
+    </article>
+  </main>
+</body>
+</html>

--- a/preview/homepage-side-links-preview.svg
+++ b/preview/homepage-side-links-preview.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="980" viewBox="0 0 1440 980">
+  <defs>
+    <style>
+      .bg { fill: #eef2f7; }
+      .panel { fill: #ffffff; stroke: #cbd5e1; stroke-width: 1.2; }
+      .shadow { fill: #dbe3ee; opacity: 0.7; }
+      .ink { fill: #20242f; }
+      .muted { fill: #5c6678; }
+      .line { stroke: #cbd5e1; stroke-width: 3; }
+      .soft-line { stroke: #d7e0ec; stroke-width: 1.2; }
+      .chip { fill: #f7faff; stroke: #cbd5e1; stroke-width: 1.2; }
+      .card { fill: #fbfdff; stroke: #cbd5e1; stroke-width: 1.2; }
+      .blue { fill: #2457a6; }
+      .green { fill: #26734d; }
+      .gold { fill: #8b6418; }
+      .purple { fill: #6550aa; }
+      .title { font-family: Georgia, 'Times New Roman', serif; font-size: 62px; font-weight: 700; letter-spacing: -2px; }
+      .subtitle { font-family: Arial, sans-serif; font-size: 25px; }
+      .h2 { font-family: Arial, sans-serif; font-size: 32px; font-weight: 700; }
+      .h3 { font-family: Arial, sans-serif; font-size: 21px; font-weight: 700; }
+      .body { font-family: Arial, sans-serif; font-size: 18px; }
+      .small { font-family: Arial, sans-serif; font-size: 15px; font-weight: 700; }
+      .sidebar-title { font-family: Arial, sans-serif; font-size: 23px; font-weight: 700; }
+    </style>
+  </defs>
+
+  <rect class="bg" width="1440" height="980"/>
+  <rect class="shadow" x="132" y="76" width="1180" height="820" rx="10"/>
+  <rect class="panel" x="120" y="64" width="1180" height="820" rx="10"/>
+
+  <rect x="120" y="64" width="1180" height="172" rx="10" fill="#ffffff"/>
+  <line class="soft-line" x1="120" y1="236" x2="1300" y2="236"/>
+  <text class="title ink" x="176" y="142">Shiyu Zhang</text>
+  <text class="subtitle muted" x="178" y="181">Complex Geometry</text>
+
+  <g transform="translate(176 284)">
+    <rect class="chip" x="0" y="0" width="292" height="34" rx="17"/>
+    <text class="body ink" x="15" y="23"><tspan font-weight="700">Researcher</tspan> Mathematics, China</text>
+    <rect class="chip" x="310" y="0" width="210" height="34" rx="17"/>
+    <text class="body ink" x="325" y="23"><tspan font-weight="700">B.S.</tspan> USTC, June 2020</text>
+    <rect class="chip" x="538" y="0" width="218" height="34" rx="17"/>
+    <text class="body ink" x="553" y="23"><tspan font-weight="700">Ph.D.</tspan> USTC, June 2026</text>
+    <rect class="chip" x="0" y="48" width="310" height="34" rx="17"/>
+    <text class="body ink" x="15" y="71"><tspan font-weight="700">Email</tspan> shiyu123@mail.ustc.edu.cn</text>
+    <rect class="chip" x="328" y="48" width="230" height="34" rx="17"/>
+    <text class="body ink" x="343" y="71"><tspan font-weight="700">Born</tspan> March 1999, China</text>
+  </g>
+
+  <line class="line" x1="176" y1="400" x2="930" y2="400"/>
+  <line class="line" x1="970" y1="284" x2="970" y2="820"/>
+
+  <g transform="translate(176 444)">
+    <text class="h2 ink" x="0" y="0">Research</text>
+    <rect class="card" x="0" y="28" width="360" height="130" rx="8"/>
+    <text class="h3 ink" x="22" y="68">Higgs sheaves over singular varieties</text>
+    <text class="body muted" x="22" y="102">Higgs sheaves, singular spaces,</text>
+    <text class="body muted" x="22" y="128">and non-abelian Hodge theory.</text>
+    <rect class="card" x="386" y="28" width="360" height="130" rx="8"/>
+    <text class="h3 ink" x="408" y="68">Curvature and rational connectedness</text>
+    <text class="body muted" x="408" y="102">Differential-geometric curvature</text>
+    <text class="body muted" x="408" y="128">and positivity questions.</text>
+
+    <rect class="card" x="0" y="184" width="746" height="70" rx="8"/>
+    <text class="h3 purple" x="22" y="228">Google Scholar</text>
+    <text class="body muted" x="238" y="228">Citation profile and publication list.</text>
+    <rect fill="#edf2f8" x="640" y="206" width="82" height="25" rx="13"/>
+    <text class="small muted" x="653" y="224">PROFILE</text>
+  </g>
+
+  <line class="line" x1="176" y1="730" x2="930" y2="730"/>
+  <g transform="translate(176 774)">
+    <text class="h2 ink" x="0" y="0">News</text>
+    <rect class="card" x="0" y="28" width="746" height="108" rx="8"/>
+    <text class="h3 ink" x="22" y="66">Non-abelian Hodge correspondence and the Miyaoka-Yau equality</text>
+    <text class="body muted" x="22" y="98">Workshop on Geometric Analysis 2026, PhD student report, May 24-29, 珠海.</text>
+    <text class="body ink" x="22" y="128">I will talk about recent work [5, 6].</text>
+  </g>
+
+  <g transform="translate(1010 304)">
+    <text class="sidebar-title ink" x="0" y="0">Quick links</text>
+    <text class="body muted" x="0" y="32">放到侧面的简洁列表，</text>
+    <text class="body muted" x="0" y="58">避免底部卡片显得太重。</text>
+
+    <rect class="card" x="0" y="92" width="228" height="70" rx="8"/>
+    <text class="h3 blue" x="20" y="135">Papers</text>
+    <text class="small muted" x="156" y="135">RESEARCH</text>
+
+    <rect class="card" x="0" y="178" width="228" height="70" rx="8"/>
+    <text class="h3 green" x="20" y="221">Talks</text>
+    <text class="small muted" x="158" y="221">UPDATES</text>
+
+    <rect class="card" x="0" y="264" width="228" height="70" rx="8"/>
+    <text class="h3 gold" x="20" y="307">Useful links</text>
+    <text class="small muted" x="160" y="307">NOTES</text>
+
+    <rect class="card" x="0" y="350" width="228" height="70" rx="8"/>
+    <text class="h3 purple" x="20" y="393">Teaching</text>
+    <text class="small muted" x="152" y="393">COURSE</text>
+  </g>
+
+  <text class="body muted" x="176" y="866">Preview: smaller title, same card style, and navigation moved from bottom cards to a right sidebar list.</text>
+</svg>


### PR DESCRIPTION
### Motivation
- Unify the website appearance and replace ad-hoc inline styles with a consistent responsive layout and typography. 
- Modernize pages for better mobile support by adding `charset`/`viewport` and a shared stylesheet. 
- Improve navigation and maintainability by converting multiple standalone HTML files to a common card/hero layout.

### Description
- Add a new stylesheet `assets/site.css` that defines the site shell, hero/header, content sections, responsive grid, and component classes. 
- Refactor multiple pages (`index.html`, `conferences/index.html`, `Teaching/Analysis 1/index.html`, `Useful links/index.html`, `Writting/Mathematics and World.html`, `Seminar/Informal discussion in Complex Geometry.html`) to use the new layout markup (`body.math-page`, `.site-shell`, `.site-card`, `.hero`, `.content`, `.section`, etc.) and link the shared stylesheet. 
- Create a new `papers/index.html` listing preprints and notes using the same template and add a preview SVG `preview/homepage-side-links-preview.svg`. 
- Clean up metadata and accessibility basics by adding `<meta charset=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a007f66acf8832d838ad2718deb784f)