### PR TITLE
Make homepage cards single column

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -235,7 +235,7 @@ a:hover {
 
 .homepage-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 192px;
+  grid-template-columns: 1fr;
   gap: 27px;
   align-items: start;
 }
@@ -245,6 +245,8 @@ a:hover {
 }
 
 .about-section {
+  display: grid;
+  gap: 13px;
   margin-top: 32px;
 }
 
@@ -253,10 +255,8 @@ a:hover {
 }
 
 .sidebar-links {
-  border-left: 2px solid var(--line);
-  padding-left: 21px;
-  position: sticky;
-  top: 22px;
+  border-top: 2px solid var(--line);
+  padding-top: 24px;
 }
 
 .sidebar-links h2 {
@@ -274,7 +274,8 @@ a:hover {
 
 .side-link-list {
   display: grid;
-  gap: 10px;
+  grid-template-columns: 1fr;
+  gap: 13px;
 }
 
 .side-link {
@@ -396,11 +397,7 @@ details.paper-entry p {
   }
 
   .sidebar-links {
-    border-left: 0;
-    border-top: 2px solid var(--line);
-    padding-left: 0;
     padding-top: 21px;
-    position: static;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -38,9 +38,10 @@
               <em class="pill"></em>
             </a>
             <div class="news-card">
-              <p>I will move into Westlake University as a postdoctorial researcher, mainly supported by the grant of <a href=https://its.westlake.edu.cn/info/1108/1806.htm"">Xin Fu</a>.</p>
+              <p>I will move into Westlake University as a postdoctorial researcher, mainly supported by the grant of <a href="https://its.westlake.edu.cn/info/1108/1806.htm">Xin Fu</a>.</p>
             </div>
           </section>
+        </div>
 
         <aside class="sidebar-links" aria-label="Quick links">
           <nav class="side-link-list">


### PR DESCRIPTION
### Motivation
- Simplify the homepage layout so each card/link occupies one full row for clearer, single-column presentation on the main page.
- Convert the right-hand quick-links sidebar into a stacked list so navigation items appear as individual boxes under the main content.

### Description
- Updated `assets/site.css` to make the homepage layout single-column by setting `.homepage-layout { grid-template-columns: 1fr; }` and adjusted related rules so cards stack vertically.
- Converted the about area to a small grid with spacing via `.about-section { display: grid; gap: 13px; }` so profile and news cards have consistent vertical spacing.
- Reworked the quick-links styling by replacing the left sidebar rules with a stacked section using `sidebar-links` top border and `side-link-list { grid-template-columns: 1fr; }` so each link renders as its own card.
- Fixed an HTML quoting bug in `index.html` for the Westlake University link and added the missing `</div>` closing tag for the main column so the quick links render after the main content.

### Testing
- ✅ Parsed `index.html` using Python `HTMLParser` (`python3 - <<'PY' ... HTMLParser ... PY`) and the parse completed successfully.
- ✅ Started a local preview server with `python3 -m http.server` to serve the site for manual inspection and the server process started.
- ⚠️ Attempted automated screenshot with Playwright (`python3 - <<'PY' ... playwright ... PY`) but it failed because Playwright is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35341a31fc832db1d47966db9695dd)